### PR TITLE
Fix colour and description validation

### DIFF
--- a/packages/widget-statistic/src/server/widget.js
+++ b/packages/widget-statistic/src/server/widget.js
@@ -26,6 +26,8 @@ class StatisticWidget {
 
 exports.validation = Joi.object({
   format: Joi.string().optional().default('%s').description('Display format'),
+  colour: Joi.string().optional().default('%s').description('Colour'),
+  description: Joi.string().optional().description('Description'),
   'font-ratio': Joi.number().default(4).description('Font ratio for display value'),
   historyView: Joi.string().only('chart', 'ticker').default('chart').description('History display format')
 })


### PR DESCRIPTION
Fixes the following error message if a custom colour is configured for a Widget. Also makes the description optional for more flexibility.

{
statusCode: 400,
error: "Bad Request",
message: "Could not register VudashWidgetStatistic due to invalid configuration: ValidationError: "colour" is not allowed"
}