### PR TITLE
Fix body validation for rest datasource

### DIFF
--- a/packages/datasource-rest/src/datasource-validation/datasource-validation.js
+++ b/packages/datasource-rest/src/datasource-validation/datasource-validation.js
@@ -6,6 +6,6 @@ exports.validation = {
   url: Joi.string().description('Url to call'),
   method: Joi.string().optional().default('get').only('get', 'post', 'put', 'options', 'delete', 'head').description('Http Method'),
   headers: Joi.object().optional().description('additional headers'),
-  payload: Joi.object().optional().description('request payload'),
+  body: Joi.object().optional().description('request payload'),
   graph: Joi.string().optional().description('Graph expression (json path) to reach json values')
 }


### PR DESCRIPTION
We noticed that the validation failed if you provide the body option.